### PR TITLE
bug(responsiveness#7)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import SectionPrincipal from "@/components/Section/Section";
 
 const Home = () => {
   return (
-    <main>
+    <main className="overflow-hidden">
       <Header />
       <Hero />
       <SectionPrincipal />


### PR DESCRIPTION
Multiple sections have absolute elements, by adding the `overflow-hidden` the problem should be fixed without the need to change the elements.