### PR TITLE
fix(css): fix locales options in mobile menu

### DIFF
--- a/src/components/DropDown/dropdown.module.css
+++ b/src/components/DropDown/dropdown.module.css
@@ -22,7 +22,7 @@
 }
 
 .body {
-  @apply p-1.5 mt-2.5 absolute top-full flex flex-col animate-[opacity_0.6s_ease-in-out];
+  @apply max-lg:ml-[-2rem] p-1.5 mt-2.5 absolute top-full flex flex-col animate-[opacity_0.6s_ease-in-out];
 }
 
 .dropdownItem {


### PR DESCRIPTION
fix locales options in mobile menu

before:

<img width="635" alt="Captura de Tela 2024-02-22 às 20 42 42" src="https://github.com/devsnorte/devsnorte-landing-page/assets/6674232/414d30eb-556a-4227-bc56-bb25a47484be">

after:

<img width="404" alt="Captura de Tela 2024-02-22 às 20 42 56" src="https://github.com/devsnorte/devsnorte-landing-page/assets/6674232/9ad1b802-036d-4802-8620-c871af4a39f0">
