### PR TITLE
Alternador de Tema Modo Escuro

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "next-i18next": "^15.2.0",
         "react": "^18",
         "react-dom": "^18",
-        "react-i18next": "^14.0.5"
+        "react-i18next": "^14.0.5",
+        "react-icons": "^5.0.1"
       },
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
@@ -7414,6 +7415,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "next-i18next": "^15.2.0",
     "react": "^18",
     "react-dom": "^18",
-    "react-i18next": "^14.0.5"
+    "react-i18next": "^14.0.5",
+    "react-icons": "^5.0.1"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",

--- a/src/components/ContextAPI/ThemeContext.tsx
+++ b/src/components/ContextAPI/ThemeContext.tsx
@@ -1,5 +1,3 @@
-// themes/ThemeContext.tsx
-
 import React, { createContext, ReactNode, useContext, useState, useEffect } from "react";
 
 type Theme = "light" | "dark";

--- a/src/components/ContextAPI/ThemeContext.tsx
+++ b/src/components/ContextAPI/ThemeContext.tsx
@@ -1,0 +1,61 @@
+// themes/ThemeContext.tsx
+
+import React, { createContext, ReactNode, useContext, useState, useEffect } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextType {
+    theme: Theme;
+    toggleTheme: () => void;
+}
+
+interface ThemeProviderProps {
+    children: ReactNode;
+}
+
+const defaultContextValue: ThemeContextType = {
+    theme: "light",
+    toggleTheme: () => {},
+};
+
+export const ThemeContext = createContext<ThemeContextType>(defaultContextValue);
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+    const [theme, setTheme] = useState<Theme>("light");
+
+    useEffect(() => {
+        const root = document.documentElement;
+        if (theme === "dark") {
+            root.style.setProperty("--foreground-rgb", "255, 255, 255");
+            root.style.setProperty("--background-start-rgb", "0, 0, 0");
+            root.style.setProperty("--background-end-rgb", "0, 0, 0");
+        } else {
+            root.style.setProperty("--foreground-rgb", "0, 0, 0");
+            root.style.setProperty("--background-start-rgb", "214, 219, 220");
+            root.style.setProperty("--background-end-rgb", "255, 255, 255");
+        }
+    }, [theme]);
+
+    useEffect(() => {
+        const storedTheme = localStorage.getItem("theme") as Theme;
+        if (storedTheme) {
+            setTheme(storedTheme);
+        }
+    }, []);
+
+    const toggleTheme = () => {
+        const newTheme = theme === "light" ? "dark" : "light";
+        localStorage.setItem("theme", newTheme);
+        setTheme(newTheme);
+    };
+
+    return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = (): ThemeContextType => {
+    const context = useContext(ThemeContext);
+    if (context === undefined) {
+        throw new Error("useTheme must be used within a ThemeProvider");
+    }
+    return context;
+};

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -5,57 +5,59 @@ import { useRouter } from "next/router";
 import Translate from "/public/icons/translate.svg";
 import { useTranslation } from "next-i18next";
 import { useLandingPageInfos } from "@/hooks/useLandingPageInfos";
+import { HiLightBulb, HiOutlineLightBulb } from "react-icons/hi";
+import { useContext } from "react";
+import { ThemeContext } from "@/components/ContextAPI/ThemeContext";
 
 interface HeaderProps extends React.HTMLAttributes<HTMLElement> {}
 
 const Header = ({ className = "", ...rest }: HeaderProps) => {
-  const router = useRouter();
-  const { t } = useTranslation();
-  const sections = useLandingPageInfos();
-  const onSelectLanguage = (value: string) => {
-    router.push(router.pathname, router.asPath, { locale: value });
-  };
+    const router = useRouter();
+    const { t } = useTranslation();
+    const sections = useLandingPageInfos();
+    const onSelectLanguage = (value: string) => {
+        router.push(router.pathname, router.asPath, { locale: value });
+    };
+    const { theme, toggleTheme } = useContext(ThemeContext);
 
-  const scrollToSection = (sectionId: string) => {
-    const section = document.getElementById(sectionId);
-    if (section) {
-      window.scrollTo({
-        top: section.offsetTop,
-        behavior: "smooth",
-      });
-    }
-  };
+    const scrollToSection = (sectionId: string) => {
+        const section = document.getElementById(sectionId);
+        if (section) {
+            window.scrollTo({
+                top: section.offsetTop,
+                behavior: "smooth",
+            });
+        }
+    };
 
-  return (
-    <header className={`flex flex-col items-center justify-center px-5`}>
-      <link rel="icon" href="/icons/favicon.svg" type="image/svg" sizes="32x32" />
-      <div className="flex justify-between w-full h-16 max-w-screen-lg pt-10">
-        <Link href="/">
-          <div className="hover:pointer"></div>
-          <Image src="/icons/logo.svg" width={188} height={60} alt="devs norte logo" className="w-full xl:w-44" />
-        </Link>
+    return (
+        <header className={`flex flex-col items-center justify-center px-5`}>
+            <link rel="icon" href="/icons/favicon.svg" type="image/svg" sizes="32x32" />
+            <div className="flex justify-between w-full h-16 max-w-screen-lg pt-10">
+                <Link href="/">
+                    <div className="hover:pointer"></div>
+                    <Image src="/icons/logo.svg" width={188} height={60} alt="devs norte logo" className="w-full xl:w-44" />
+                </Link>
 
-        <div className="flex gap-[10px] items-center">
-          <div className="hover:pointer">
-            <Dropdown
-              placeholder={<Image src="/icons/menu.svg" width={50} height={50} alt="menu" className="w-6 h-6" />}
-              onSelect={(value) => scrollToSection(value as string)}
-              data={[...sections.map((section) => ({ label: section.title, value: section.title }))]}
-            />
-          </div>
-          <Dropdown
-            placeholder={<Translate className="w-6 h-6" />}
-            onSelect={(value) => onSelectLanguage(value as string)}
-            data={[
-              { label: "Portugues", value: "pt" },
-              { label: "English", value: "en" },
-              { label: "Espanhol", value: "es" },
-            ]}
-          />
-        </div>
-      </div>
-    </header>
-  );
+                <div className="flex gap-[10px] items-center">
+                    <div className="hover:pointer">
+                        <Dropdown placeholder={<Image src="/icons/menu.svg" width={50} height={50} alt="menu" className="w-6 h-6" />} onSelect={(value) => scrollToSection(value as string)} data={[...sections.map((section) => ({ label: section.title, value: section.title }))]} />
+                    </div>
+                    <Dropdown
+                        placeholder={<Translate className="w-6 h-6" />}
+                        onSelect={(value) => onSelectLanguage(value as string)}
+                        data={[
+                            { label: "Portugues", value: "pt" },
+                            { label: "English", value: "en" },
+                            { label: "Espanhol", value: "es" },
+                        ]}
+                    />
+
+                    <div className="hover:cursor-pointer">{theme === "light" ? <HiLightBulb size={48} onClick={toggleTheme} /> : <HiOutlineLightBulb size={48} onClick={toggleTheme} />}</div>
+                </div>
+            </div>
+        </header>
+    );
 };
 
 export default Header;

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -7,41 +7,41 @@ import { useEffect, useRef } from "react";
 import { useTranslation } from "next-i18next";
 
 const Hero = () => {
-  const { t } = useTranslation();
-  const textHeroSubtitleRef = useRef(null);
+    const { t } = useTranslation();
+    const textHeroSubtitleRef = useRef(null);
 
-  useEffect(() => {
-    const textHeroSubtitle = textHeroSubtitleRef.current;
+    useEffect(() => {
+        const textHeroSubtitle = textHeroSubtitleRef.current;
 
-    gsap.fromTo(
-      textHeroSubtitle,
-      {
-        opacity: 0,
-        duration: 3,
-        y: 0,
-      },
-      {
-        opacity: 1,
-        duration: 2,
-        y: 20,
-        ease: "power4.out",
-      }
+        gsap.fromTo(
+            textHeroSubtitle,
+            {
+                opacity: 0,
+                duration: 3,
+                y: 0,
+            },
+            {
+                opacity: 1,
+                duration: 2,
+                y: 20,
+                ease: "power4.out",
+            }
+        );
+    }, []);
+
+    return (
+        <div className="px-6">
+            <div className="mx-auto my-64 relative max-w-screen-md">
+                <hr className={`w-20 absolute right-1 -top-10 ${css.line}`} />
+                <ImageHero />
+                <p className="mt-5 text-base lg:text-3xl opacity-0" ref={textHeroSubtitleRef}>
+                    {t("heroSubtitle")}
+                </p>
+                <hr className={`w-40 absolute right-0 ${css.line}`} />
+            </div>
+            <Detail />
+        </div>
     );
-  }, []);
-
-  return (
-    <div className="px-6">
-      <div className="mx-auto my-64 relative max-w-screen-md">
-        <hr className={`w-20 absolute right-1 -top-10 ${css.line}`} />
-        <ImageHero />
-        <p className="mt-5 text-base lg:text-3xl opacity-0" ref={textHeroSubtitleRef}>
-          {t("heroSubtitle")}
-        </p>
-        <hr className={`w-40 absolute right-0 ${css.line}`} />
-      </div>
-      <Detail />
-    </div>
-  );
 };
 
 export default Hero;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,13 +3,16 @@ import { AppProps } from "next/app";
 import { Poppins } from "next/font/google";
 const poppins = Poppins({ subsets: ["latin"], weight: ["100", "300", "400", "700", "600"], variable: "--font-poppins" });
 import "./globals.css";
+import { ThemeProvider } from "@/components/ContextAPI/ThemeContext";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <main className={poppins.className}>
-      <Component {...pageProps} />
-    </main>
-  );
+    return (
+        <ThemeProvider>
+            <main className={poppins.className}>
+                <Component {...pageProps} />
+            </main>
+        </ThemeProvider>
+    );
 }
 
 export default appWithTranslation(MyApp);


### PR DESCRIPTION
# Olá pessoal!

Consegui implementar um **tema claro e escuro** adicionando um alternador de tema ao cabeçalho, conforme visto aqui:

![Tema do Cabeçalho](https://github.com/devsnorte/devsnorte-landing-page/assets/97119018/501f0e22-1b93-40d4-b3bb-2fbad1c9be82)

## Uso
Clique na lâmpada e ela alternará entre as cores que você definiu no seu arquivo `global.css`. Aqui estão algumas imagens do produto final:

### Modo Claro
![Modo Claro](https://github.com/devsnorte/devsnorte-landing-page/assets/97119018/eea28838-731e-498d-bfce-a51449f5c15e)

### Modo Escuro
![Modo Escuro](https://github.com/devsnorte/devsnorte-landing-page/assets/97119018/7a6b785c-9623-497a-81ac-dd9428bfc45f)

**Nota:** Esqueci de desativar o Prettier, então alguns espaçamentos no código podem parecer diferentes, mas isso não deve mudar o funcionamento do código de forma alguma!

Me avise se eu perdi algo, ou se você quer que eu mude alguma coisa! Obrigado por me deixarem trabalhar nisso, **foi divertido**! Conecte-se comigo no LinkedIn!
[LinkedIn](https://www.linkedin.com/in/kedgard-cordero/)